### PR TITLE
Removing uneeded install requirements

### DIFF
--- a/.github/workflows/deploy-new-bot-live.yml
+++ b/.github/workflows/deploy-new-bot-live.yml
@@ -4,20 +4,6 @@ on:
 env:
   REPO_NAME: ${{ github.event.repository.name }}-live
 jobs:
-  install-requirements:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Installing requirements for ${{ env.REPO_NAME }}
-        uses: fifsky/ssh-action@master
-        with:
-          command: |
-            sudo apt-get install git -y
-            sudo apt-get install python3-pip -y
-            pip install -r /root/${{ env.REPO_NAME }}/requirements.txt
-          host: ${{ secrets.HOST }}
-          user: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-
   deploy-via-sftp:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removing this step from live deployment as it's not needed. All requirements should be installed on the server by the test Pipeline