### PR TITLE
Increase ready up time to 5mins

### DIFF
--- a/cogs/match.py
+++ b/cogs/match.py
@@ -136,7 +136,7 @@ class ReadyButton(ui.View):
 
     @tasks.loop(seconds=3)
     async def disable_button(self):
-        if (datetime.now() - self.time_of_execution).seconds >= 180:
+        if (datetime.now() - self.time_of_execution).seconds >= 300:
             try:
                 await self.msg.edit(
                     "Game was cancelled as everyone was not ready.", view=None

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -166,7 +166,7 @@ class ReadyButton(ui.View):
 
             self.players_ready.append(inter.author.id)
             await inter.message.edit(
-                f"{len(self.players_ready)}/10 Players are ready!\nReady up before <t:{int(datetime.timestamp((self.time_of_execution + timedelta(seconds=170))))}:t>",
+                f"{len(self.players_ready)}/10 Players are ready!\nReady up before <t:{int(datetime.timestamp((self.time_of_execution + timedelta(seconds=290))))}:t>",
                 embed=await self.gen_embed(inter),
             )
 

--- a/cogs/win.py
+++ b/cogs/win.py
@@ -44,20 +44,20 @@ class Win(Cog):
                 blue = 6
         else:
             msg = await channel.send("Which team won?")
-            await msg.add_reaction("🔴")
             await msg.add_reaction("🔵")
+            await msg.add_reaction("🔴")
             self.active_win_commands.append(channel.id)
 
             while True:
                 reaction, user = await self.bot.wait_for(
                     "reaction_add",
-                    check=lambda reaction, user: str(reaction.emoji) in ["🔵", "🔴"]
+                    check=lambda reaction, user: str(reaction.emoji) in ["🔴", "🔵"]
                     and user.id in [member[0] for member in member_data],
                 )
 
-                if str(reaction.emoji) == "🔵":
-                    blue += 1
                 if str(reaction.emoji) == "🔴":
+                    blue += 1
+                if str(reaction.emoji) == "🔵":
                     red += 1
 
                 if blue >= 6 or red >= 6:  # CHECK


### PR DESCRIPTION
- Increasing the time needed to ready up to 5minutes
- Fix bug with the /win - We switched the sides on this pull request https://github.com/HenrySpartGlobal/InHouseQueue/commit/c76c48be75259325ac155e3190f4ff56b7ac0fe1 but we forgot to also switch the sides on the winner selection so it was giving the win to the wrong team.
- Also switched the emojis around to line up with the team selection