### PR TITLE
Moving SQL file into /db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ HOSTING.md
 LICENSE
 README.md
 .gitignore
+more-details.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ LICENSE
 README.md
 .gitignore
 more-details.md
+db/main.sqlite

--- a/.github/workflows/backup-db-live.yml
+++ b/.github/workflows/backup-db-live.yml
@@ -11,7 +11,7 @@ jobs:
         uses: fifsky/ssh-action@master
         with:
           command: |
-            cd /root/${{ env.REPO_NAME }} || exit
+            cd /root/${{ env.REPO_NAME }}/db || exit
             DATE=$(date '+%Y-%m-%d-%H:%M:%S')
             sqlite3 main.sqlite ".backup m_database-${DATE}.sq3.bak"
             mv m_database-${DATE}.sq3.bak /root/s3-bucket/${{ env.REPO_NAME }}

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -11,7 +11,7 @@ jobs:
         uses: fifsky/ssh-action@master
         with:
           command: |
-            cd /root/${{ env.REPO_NAME }} || exit
+            cd /root/${{ env.REPO_NAME }}/db || exit
             DATE=$(date '+%Y-%m-%d-%H:%M:%S')
             sqlite3 main.sqlite ".backup m_database-${DATE}.sq3.bak"
             mv m_database-${DATE}.sq3.bak /root/s3-bucket/${{ env.REPO_NAME }}

--- a/.github/workflows/update-bot-live.yml
+++ b/.github/workflows/update-bot-live.yml
@@ -13,7 +13,7 @@ jobs:
           uses: fifsky/ssh-action@master
           with:
             command: |
-              cd /root/${{ env.REPO_NAME }} || exit
+              cd /root/${{ env.REPO_NAME }}/db || exit
               DATE=$(date '+%Y-%m-%d-%H:%M:%S')
               sqlite3 main.sqlite ".backup m_database-${DATE}.sq3.bak"
               mv m_database-${DATE}.sq3.bak /root/s3-bucket/${{ env.REPO_NAME }}

--- a/.github/workflows/update-bot.yml
+++ b/.github/workflows/update-bot.yml
@@ -13,7 +13,7 @@ jobs:
           uses: fifsky/ssh-action@master
           with:
             command: |
-              cd ${{ env.REPO_NAME }} || exit
+              cd ${{ env.REPO_NAME }}/db || exit
               DATE=$(date '+%Y-%m-%d-%H:%M:%S')
               sqlite3 main.sqlite ".backup m_database-${DATE}.sq3.bak"
               mv m_database-${DATE}.sq3.bak /root/s3-bucket/${{ env.REPO_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,8 @@ dmypy.json
 .pyre/
 
 # Database
-db/
+db/main.sqlite
+main.sqlite
 
 # Intellj IDE stuff
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Database
 main.sqlite
+
+# Intellj IDE stuff
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ dmypy.json
 .pyre/
 
 # Database
-main.sqlite
+db/
 
 # Intellj IDE stuff
 .idea

--- a/main.py
+++ b/main.py
@@ -18,30 +18,30 @@ class MyBot(commands.Bot):
         super().__init__(*args, **kwargs)
 
     async def commit(self):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             await db.commit()
 
     async def execute(self, query, *values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 await cur.execute(query, tuple(values))
             await db.commit()
 
     async def executemany(self, query, values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 await cur.executemany(query, values)
             await db.commit()
 
     async def fetchval(self, query, *values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 exe = await cur.execute(query, tuple(values))
                 val = await exe.fetchone()
             return val[0] if val else None
 
     async def fetchrow(self, query, *values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 exe = await cur.execute(query, tuple(values))
                 row = await exe.fetchmany(size=1)
@@ -52,14 +52,14 @@ class MyBot(commands.Bot):
             return row
 
     async def fetchmany(self, query, size, *values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 exe = await cur.execute(query, tuple(values))
                 many = await exe.fetchmany(size)
             return many
 
     async def fetch(self, query, *values):
-        async with aiosqlite.connect("main.sqlite") as db:
+        async with aiosqlite.connect("db/main.sqlite") as db:
             async with db.cursor() as cur:
                 exe = await cur.execute(query, tuple(values))
                 all = await exe.fetchall()

--- a/more-details.md
+++ b/more-details.md
@@ -1,9 +1,12 @@
 ## Running the bot with Docker - Available on Docker [hub:](https://hub.docker.com/repository/docker/henrykoleoso/in-house-queue)
 1.  Pull the latest image `docker pull henrykoleoso/in-house-queue`
-2. Run the bot `docker run -v db:/app -e TOKEN=[discord-token] -d henrykoleoso/in-house-queue`
+2. Run the bot `docker run -v db:/app/db -e TOKEN=[discord-token] -d henrykoleoso/in-house-queue`
 3. Stop the bot `docker stop [containerid]`
 4. View the docker repository for specific tags/versions that are [available:](https://hub.docker.com/repository/docker/henrykoleoso/in-house-queue) you can then pull a specific version/tag `docker pull henrykoleoso/in-house-queue:v1.0.2-beta`
 5. Details of what is included in the versions are on the [release](https://github.com/HenrySpartGlobal/InHouseQueue/releases) page.
+
+IMPORTANT:
+`-v db:/app/db` creates a named volume. It is called `db` (feel free to change this if you like). This volume is attached to the docker container, and it contains the `main.sqlite` which is your DATABASE. It has all the important data about your server, leaderboard, set channels, wins and so on. Keep it safe and don't forget to attach it when you pull a new image!
 
 ## Run from source
 ### Prerequisites


### PR DESCRIPTION
Moving the main.sql file into a new directory, makes it much easier for docker deployments. 

# Local test
Do an entire end-to-end flow with the bot locally first 

# Testing - Use the Test bot
1. Back up the DB using the pipeline
2. Set a channel with the InHouse Test (putting something in the db)
3. Stop the service
4. Merge this - this may create a blank main.sqlite file
5. Stop the service
6. Replace the main.sqlite from root, into the new directory 
7. Start the service
8. Make sure DB data is persistent - Do /start in the channel from step 2, and this *should* work 
9. Test other pipeline stuff - Backup DB, and Update Pipelines