### PR TITLE
Reset bug fix, rank command, void command, switch team command, op.gg

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -403,6 +403,21 @@ class Admin(Cog):
             await m.pin()
         except:
             pass
+    
+    @admin.command()
+    async def void(self, ctx, game_id):
+        await self.bot.execute(f"DELETE FROM games WHERE game_id = '{game_id}'")
+        await self.bot.execute(f"DELETE FROM game_member_data WHERE game_id = '{game_id}'")
+        await self.bot.execute(f"DELETE FROM ready_ups WHERE game_id = '{game_id}'")
+
+        await ctx.send(embed=success(f"All records for Game **{game_id}** were deleted."))
+
+    @admin_slash.sub_command(name="void")
+    async def void_slash(self, ctx, game_id):
+        """
+        Delete records of a game.
+        """
+        await self.void(ctx, game_id)
 
 
 def setup(bot):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -111,6 +111,7 @@ class Admin(Cog):
                 "SELECT * FROM games WHERE game_id = ? ", entry[3]
             )
             if not game_data:
+                print("Test")
                 await self.bot.execute(
                     "DELETE FROM game_member_data WHERE author_id = ? ", member.id
                 )
@@ -138,6 +139,10 @@ class Admin(Cog):
 
     @reset.command()
     async def queue(self, ctx, game_id):
+        game_data = await self.bot.fetchrow(f"SELECT * FROM games WHERE game_id = '{game_id}'")
+        if game_data:
+            return await ctx.send(embed=error("You cannot reset an ongoing game."))
+
         member_data = await self.bot.fetchrow(
             "SELECT * FROM game_member_data WHERE game_id = ?", game_id
         )

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -71,7 +71,7 @@ class Admin(Cog):
     @admin_slash.sub_command()
     async def queue_preference(self, ctx, preference = Param(choices=[OptionChoice("Multi Queue", "1"), OptionChoice("Single Queue", "2")])):
         """
-        Decide if players can be in multiple queues
+        Decide if players can be in multiple queues at once
         """
         preference_data = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {ctx.guild.id}")
         if preference_data:
@@ -132,7 +132,7 @@ class Admin(Cog):
     @reset_slash.sub_command(name="user")
     async def user_slash(self, ctx, member: Member):
         """
-        Remove a user from all queues. Requires someone to rejoin the queue to refresh the Embed.
+        Remove a user from all queues. Rejoin the queue to refresh the Embed.
         """
         await self.user(ctx, member)
 
@@ -140,7 +140,7 @@ class Admin(Cog):
     async def queue(self, ctx, game_id):
         game_data = await self.bot.fetchrow(f"SELECT * FROM games WHERE game_id = '{game_id}'")
         if game_data:
-            return await ctx.send(embed=error("You cannot reset an ongoing game."))
+            return await ctx.send(embed=error("You cannot reset an ongoing game. To cancel an ongoing game, please use `/admin cancel [member]`"))
 
         member_data = await self.bot.fetchrow(
             "SELECT * FROM game_member_data WHERE game_id = ?", game_id
@@ -156,7 +156,7 @@ class Admin(Cog):
     @reset_slash.sub_command(name="queue")
     async def queue_slash(self, ctx, game_id: str):
         """
-        Reset a queue. Requires someone to rejoin the queue to refresh the Embed.
+        Reset a queue. Rejoin the queue to refresh the Embed.
         """
         await self.queue(ctx, game_id)
 
@@ -246,7 +246,7 @@ class Admin(Cog):
         team=Param(choices=[OptionChoice("Red", "red"), OptionChoice("Blue", "blue")]),
     ):
         """
-        Change the winner of a game.
+        Change the winner of a finished game.
         """
         await self.change_winner(ctx, game_id, team)
 
@@ -374,7 +374,7 @@ class Admin(Cog):
     @admin_slash.sub_command(name="top_ten")
     async def leaderboard_persistent_slash(self, ctx, channel: TextChannel):
         """
-        Create persistent leaderboard in a channel which automatically updates itself.
+        Create dynamic Top 10 leaderboard
         """
         embed = await self.leaderboard_persistent(channel)
         msg = await channel.send(embed=embed)
@@ -439,7 +439,7 @@ class Admin(Cog):
     @admin_slash.sub_command(name="void")
     async def void_slash(self, ctx, game_id):
         """
-        Delete records of a game.
+        Purge all records of a game. Use with care.
         """
         await self.void(ctx, game_id)
 
@@ -451,7 +451,7 @@ class Admin(Cog):
         ]
     )):
         """
-        Enable/Disable skill based match making.
+        Enable/Disable SkillBased match making.
         """
         if int(preference):
             await self.bot.execute(f"DELETE FROM switch_team_preference WHERE guild_id = {ctx.guild.id}")

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -99,7 +99,6 @@ class Admin(Cog):
         """
         Reset your server's leaderboard.
         """
-        await ctx.response.defer()
         await self.leaderboard(ctx)
 
     @reset.command()
@@ -135,7 +134,6 @@ class Admin(Cog):
         """
         Remove a user from all queues. Requires someone to rejoin the queue to refresh the Embed.
         """
-        await ctx.response.defer()
         await self.user(ctx, member)
 
     @reset.command()
@@ -156,7 +154,6 @@ class Admin(Cog):
         """
         Reset a queue. Requires someone to rejoin the queue to refresh the Embed.
         """
-        await ctx.response.defer()
         await self.queue(ctx, game_id)
 
     @admin.command()
@@ -247,7 +244,6 @@ class Admin(Cog):
         """
         Change the winner of a game.
         """
-        await ctx.response.defer()
         await self.change_winner(ctx, game_id, team)
 
     @admin.command()
@@ -277,7 +273,6 @@ class Admin(Cog):
         """
         Announce the winner of a game. Skips voting. The game must be in progress.
         """
-        await ctx.response.defer()
         await self.winner(ctx, role)
 
     @admin.group()
@@ -329,7 +324,6 @@ class Admin(Cog):
         """
         Cancel the member's game.
         """
-        await ctx.response.defer()
         await self.cancel(ctx, member)
 
     async def leaderboard_persistent(self, channel):
@@ -418,6 +412,25 @@ class Admin(Cog):
         Delete records of a game.
         """
         await self.void(ctx, game_id)
+
+    @admin_slash.sub_command(name="switch_team")
+    async def switch_team(self, ctx, preference = Param(
+        choices=[
+            OptionChoice('Enabled', '1'),
+            OptionChoice('Disabled', '0')
+        ]
+    )):
+        """
+        Set queue switch team preference.
+        """
+        if not int(preference):
+            await self.bot.execute(f"DELETE FROM switch_team_preference WHERE guild_id = {ctx.guild.id}")
+        else:
+            await self.bot.execute(
+                f"INSERT INTO switch_team_preference(guild_id) VALUES($1)",
+                ctx.guild.id
+            )
+        await ctx.send(embed=success(f"Switch team preference changed successfully."))
 
 
 def setup(bot):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -111,7 +111,6 @@ class Admin(Cog):
                 "SELECT * FROM games WHERE game_id = ? ", entry[3]
             )
             if not game_data:
-                print("Test")
                 await self.bot.execute(
                     "DELETE FROM game_member_data WHERE author_id = ? ", member.id
                 )

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -126,7 +126,7 @@ class Admin(Cog):
                 if msg:
                     if msg.components[0].children[0].label == "Ready Up!":
                         self.game_id = entry[3]
-                        await msg.edit(view=QueueButtons(self.bot), embed = await QueueButtons.gen_embed(self, msg))
+                        await msg.edit(view=QueueButtons(self.bot), embed = await QueueButtons.gen_embed(self, msg), content=" ")
 
         await ctx.send(embed=success(f"{member.mention} was removed from all active queues."))
 

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -123,9 +123,10 @@ class Admin(Cog):
                     channel = self.bot.get_channel(entry[5])
                     msg = await channel.fetch_message(entry[4])
                 
-                if msg.components[0].children[0].label == "Ready Up!":
-                    self.game_id = entry[3]
-                    await msg.edit(view=QueueButtons(self.bot), embed = await QueueButtons.gen_embed(self, msg))
+                if msg:
+                    if msg.components[0].children[0].label == "Ready Up!":
+                        self.game_id = entry[3]
+                        await msg.edit(view=QueueButtons(self.bot), embed = await QueueButtons.gen_embed(self, msg))
 
         await ctx.send(embed=success(f"{member.mention} was removed from all active queues."))
 

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -1,5 +1,5 @@
-from core import embeds
-from disnake import TextChannel
+from core import embeds, buttons
+from disnake import TextChannel, Embed, Color
 from disnake.ext.commands import Cog, command, slash_command
 
 
@@ -39,6 +39,18 @@ class ChannelCommands(Cog):
 
     @command(aliases=["channel"])
     async def setchannel(self, ctx, channel: TextChannel):
+        view = buttons.ConfirmationButtons(ctx.author.id)
+        await ctx.send(
+            embed=Embed(title=":warning: Notice", description=f"Messages in {channel.mention} will automatically be deleted to keep the queue channel clean, do you want to proceed?", color=Color.yellow()),
+            view=view,
+        )
+        await view.wait()
+        if view.value is None:
+           return
+        elif view.value:
+            pass
+        else:
+            return await ctx.send(embed=embeds.success("Process aborted."))
         data = await self.bot.fetchrow(
             f"SELECT * FROM queuechannels WHERE channel_id = {channel.id}"
         )

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -64,7 +64,6 @@ class ChannelCommands(Cog):
         """
         Set a channel to be used as the queue.
         """
-        await ctx.response.defer()
         await self.setchannel(ctx, channel)
 
     @command()
@@ -104,7 +103,6 @@ class ChannelCommands(Cog):
         """
         Set a channel for winner log.
         """
-        await ctx.response.defer()
         await self.setwinnerlog(ctx, channel)
 
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -173,6 +173,14 @@ class Events(Cog):
             """
         )
 
+        await bot.execute(
+            """
+            CREATE TABLE IF NOT EXISTS switch_team_preference(
+                guild_id INTEGER
+            )
+            """
+        )
+
     @Cog.listener()
     async def on_ready(self):
         print("*********\nBot is Ready.\n*********")

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -74,7 +74,9 @@ class Events(Cog):
                 author_id INTEGER,
                 role TEXT,
                 team TEXT,
-                game_id TEXT
+                game_id TEXT,
+                queue_id INTEGER,
+                channel_id INTEGER
             )
             """
         )
@@ -190,7 +192,7 @@ class Events(Cog):
 
             if self.bot.user.id == 1018498965022445638:  # Testing bot ID
                 channel = self.bot.get_channel(
-                    1032359147833921616
+                    1045254299430694912
                 )  # Testing Server Channel
             else:
                 channel = self.bot.get_channel(

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -69,7 +69,6 @@ class Help(Cog):
 
     @slash_command(name="help", description="See all available features.")
     async def help_slash(self, ctx):
-        await ctx.response.defer()
         await self.help_menu(ctx)
 
     @command()

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -171,7 +171,6 @@ class Leaderboard(Cog):
         """
         Check your rank in the server.
         """
-        await ctx.response.defer()
         await self.rank(ctx, type)
 
 

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -102,6 +102,79 @@ class Leaderboard(Cog):
         """
         await self.leaderboard(ctx, type)
 
+    @command()
+    async def rank(self, ctx, type):
+        if type.lower() not in ['mvp', 'mmr']:
+            return await ctx.send(embed=error("Rank type can either be `mmr` or `mvp`."))
+
+        if type == 'mmr':
+            user_data = await self.bot.fetch(
+                f"SELECT * FROM mmr_rating WHERE guild_id = {ctx.guild.id}"
+            )
+            user_data = sorted(list(user_data), key=lambda x: float(x[2]) - (2 * float(x[3])), reverse=True)
+        else:
+            user_data = await self.bot.fetch(
+                f"SELECT * FROM mvp_points WHERE guild_id = {ctx.guild.id}"
+            )
+            user_data = sorted(list(user_data), key=lambda x: x[2], reverse=True)
+
+        if not user_data:
+            return await ctx.send(embed=error(f"No entries to present {type} rank from."))
+        
+        if ctx.author.id not in [x[1] for x in user_data]:
+            return await ctx.send(embed=error("You are not yet ranked."))
+        
+        embed = Embed(title=f"⏫ Rank of {ctx.author.name}", color=ctx.author.color)
+        if ctx.author.avatar:
+            embed.set_thumbnail(url=ctx.author.avatar.url)
+        async def add_field(data) -> None:
+            user_data = await self.bot.fetchrow(f"SELECT * FROM points WHERE user_id = {data[1]}")
+            if user_data:
+                wins = user_data[2]
+                losses = user_data[3]
+            else:
+                wins = 0
+                losses = 0
+            total = wins + losses
+            if not total:
+                total = 1
+
+            percentage = round((wins / total) * 100, 2)
+
+            if type == 'mvp':
+                embed.add_field(
+                    name=f"#{i+1}",
+                    value=f"<@{data[1]}> - **{wins}** Wins - **{percentage}%** WR - **{data[2]}x** MVP",
+                    inline=False,
+                )
+            else:
+                skill = round(float(data[2]) - (2 * float(data[3])), 2)
+                if data[4] >= 10:
+                    display_mmr = f"**{int(skill*100)}** MMR"
+                else:
+                    display_mmr = f"**{data[4]}/10** Games Played"
+                
+                embed.add_field(
+                    name=f"#{i + 1}",
+                    value=f"<@{data[1]}> - **{wins}** Wins - **{percentage}%** WR - {display_mmr}",
+                    inline=False,
+                )
+
+        for i, data in enumerate(user_data):
+            if data[1] == ctx.author.id:
+                await add_field(data)
+                await ctx.send(embed=embed)
+                break
+
+    @slash_command(name="rank")
+    async def rank_slash(self, ctx, type = Param(choices=[OptionChoice('MMR', 'mmr'), OptionChoice('MVP', 'mvp')])):
+        """
+        Check your rank in the server.
+        """
+        await ctx.response.defer()
+        await self.rank(ctx, type)
+
+
 
 def setup(bot):
     bot.add_cog(Leaderboard(bot))

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -139,8 +139,16 @@ class ReadyButton(ui.View):
     @tasks.loop(seconds=1)
     async def disable_button(self):
         if self.msg:
+            # Update the stored message and stop timer if ready up phase was removed
+            msg = self.bot.get_message(self.msg.id)
+            if not msg:
+                msg = await self.msg.channel.fetch_message(self.msg.id)
+                if msg:
+                    self.msg = msg
+
             if not self.msg.components[0].children[0].label == "Ready Up!":
-                return self.disable_button.stop()
+                self.disable_button.stop()
+                return
         if (datetime.now() - self.time_of_execution).seconds >= 300:
             if self.msg:
                 ready_ups = await self.bot.fetch(

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -139,6 +139,8 @@ class ReadyButton(ui.View):
     async def disable_button(self):
         if (datetime.now() - self.time_of_execution).seconds >= 300:
             if self.msg:
+                if not self.msg.components[0].children[0].label == "Ready Up!":
+                    return self.disable_button.stop()
                 ready_ups = await self.bot.fetch(
                     f"SELECT user_id FROM ready_ups WHERE game_id = '{self.game_id}'"
                 )

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -243,8 +243,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            if len(ready_ups) == 2:
-            # if len(ready_ups) == 10:
+            # if len(ready_ups) == 2:
+            if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -348,6 +348,18 @@ class ReadyButton(ui.View):
                                     f"Only lobby **members** votes will count.\n \n"
                                     f"**Optional:** Enter `{self.game_id}` as custom game name and password.",
                         color=Color.yellow(),
+                    )
+                )
+                await game_lobby.send(
+                    embed=Embed(
+                        title="<:opgg:1052529528913805402> Multi OP.GG",
+                        description=f"**League of Legends**\n \n"
+                                    f"**Copy** and **Paste** for Red or Blue Teams Multi op.gg link, then pick a **region**.\n"
+                                    f"🔵 - `/opgg game_id: {self.game_id} team: Blue region: `\n"
+                                    f"🔴 - `/opgg game_id: {self.game_id} team: Red region: `\n \n"
+                                    f"Your discord Nickname **must** be in this format:`IGN: Faker` or `Faker` \n \n"
+                                    f":warning: If your Discord Nickname is currently **not** your IGN, change it **AFTER** this match.",
+                        color=Color.blurple(),
                     )
                 )
 
@@ -490,8 +502,8 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        if checks_passed == 1:
-        # if checks_passed == len(self.children) - 2:
+        # if checks_passed == 1:
+        if checks_passed == len(self.children) - 2:
 
             st_pref = await self.bot.fetchrow(f"SELECT * FROM switch_team_preference WHERE guild_id = {inter.guild.id}")
             if not st_pref:
@@ -500,20 +512,20 @@ class QueueButtons(ui.View):
                 )
 
                 # CHECK
-                roles_occupation = {
-                    "TOP": [],
-                    "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-                    "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-                    "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-                    "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-                }
                 # roles_occupation = {
                 #     "TOP": [],
-                #     "JUNGLE": [],
-                #     "MID": [],
-                #     "ADC": [],
-                #     "SUPPORT": []
+                #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+                #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+                #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+                #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
                 # }
+                roles_occupation = {
+                    "TOP": [],
+                    "JUNGLE": [],
+                    "MID": [],
+                    "ADC": [],
+                    "SUPPORT": []
+                }
 
                 for data in member_data:
                     member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -138,6 +138,8 @@ class ReadyButton(ui.View):
 
     @tasks.loop(seconds=1)
     async def disable_button(self):
+        await self.bot.wait_until_ready()
+        
         if self.msg:
             # Update the stored message and stop timer if ready up phase was removed
             msg = self.bot.get_message(self.msg.id)
@@ -145,6 +147,8 @@ class ReadyButton(ui.View):
                 msg = await self.msg.channel.fetch_message(self.msg.id)
                 if msg:
                     self.msg = msg
+            else:
+                self.msg = msg
 
             if not self.msg.components[0].children[0].label == "Ready Up!":
                 self.disable_button.stop()

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -230,8 +230,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            if len(ready_ups) == 2:
-            # if len(ready_ups) == 10:
+            # if len(ready_ups) == 2:
+            if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -477,8 +477,8 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        if checks_passed == 1:
-        # if checks_passed == len(self.children) - 2:
+        # if checks_passed == 1:
+        if checks_passed == len(self.children) - 2:
 
             st_pref = await self.bot.fetchrow(f"SELECT * FROM switch_team_preference WHERE guild_id = {inter.guild.id}")
             if not st_pref:
@@ -487,20 +487,20 @@ class QueueButtons(ui.View):
                 )
 
                 # CHECK
-                roles_occupation = {
-                    "TOP": [],
-                    "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-                    "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-                    "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-                    "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-                }
                 # roles_occupation = {
                 #     "TOP": [],
-                #     "JUNGLE": [],
-                #     "MID": [],
-                #     "ADC": [],
-                #     "SUPPORT": []
+                #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+                #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+                #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+                #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
                 # }
+                roles_occupation = {
+                    "TOP": [],
+                    "JUNGLE": [],
+                    "MID": [],
+                    "ADC": [],
+                    "SUPPORT": []
+                }
 
                 for data in member_data:
                     member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -227,8 +227,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            if len(ready_ups) == 2:
-            # if len(ready_ups) == 10:
+            # if len(ready_ups) == 2:
+            if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -473,27 +473,27 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        if checks_passed == 1:
-        # if checks_passed == len(self.children) - 1:
+        # if checks_passed == 1:
+        if checks_passed == len(self.children) - 1:
             member_data = await self.bot.fetch(
                 f"SELECT * FROM game_member_data WHERE game_id = '{self.game_id}'"
             )
 
             # CHECK
-            roles_occupation = {
-                "TOP": [],
-                "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-                "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-                "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-                "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-            }
             # roles_occupation = {
             #     "TOP": [],
-            #     "JUNGLE": [],
-            #     "MID": [],
-            #     "ADC": [],
-            #     "SUPPORT": []
+            #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+            #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+            #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+            #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
             # }
+            roles_occupation = {
+                "TOP": [],
+                "JUNGLE": [],
+                "MID": [],
+                "ADC": [],
+                "SUPPORT": []
+            }
 
             for data in member_data:
                 member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -229,8 +229,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            # if len(ready_ups) == 2:
-            if len(ready_ups) == 10:
+            if len(ready_ups) == 2:
+            # if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -475,27 +475,27 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        # if checks_passed == 1:
-        if checks_passed == len(self.children) - 1:
+        if checks_passed == 1:
+        # if checks_passed == len(self.children) - 1:
             member_data = await self.bot.fetch(
                 f"SELECT * FROM game_member_data WHERE game_id = '{self.game_id}'"
             )
 
             # CHECK
-            # roles_occupation = {
-            #     "TOP": [],
-            #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-            #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-            #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-            #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-            # }
             roles_occupation = {
                 "TOP": [],
-                "JUNGLE": [],
-                "MID": [],
-                "ADC": [],
-                "SUPPORT": []
+                "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+                "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+                "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+                "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
             }
+            # roles_occupation = {
+            #     "TOP": [],
+            #     "JUNGLE": [],
+            #     "MID": [],
+            #     "ADC": [],
+            #     "SUPPORT": []
+            # }
 
             for data in member_data:
                 member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -138,10 +138,11 @@ class ReadyButton(ui.View):
 
     @tasks.loop(seconds=1)
     async def disable_button(self):
+        if self.msg:
+            if not self.msg.components[0].children[0].label == "Ready Up!":
+                return self.disable_button.stop()
         if (datetime.now() - self.time_of_execution).seconds >= 300:
             if self.msg:
-                if not self.msg.components[0].children[0].label == "Ready Up!":
-                    return self.disable_button.stop()
                 ready_ups = await self.bot.fetch(
                     f"SELECT user_id FROM ready_ups WHERE game_id = '{self.game_id}'"
                 )
@@ -230,8 +231,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            # if len(ready_ups) == 2:
-            if len(ready_ups) == 10:
+            if len(ready_ups) == 2:
+            # if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -477,8 +478,8 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        # if checks_passed == 1:
-        if checks_passed == len(self.children) - 2:
+        if checks_passed == 1:
+        # if checks_passed == len(self.children) - 2:
 
             st_pref = await self.bot.fetchrow(f"SELECT * FROM switch_team_preference WHERE guild_id = {inter.guild.id}")
             if not st_pref:
@@ -487,20 +488,20 @@ class QueueButtons(ui.View):
                 )
 
                 # CHECK
-                # roles_occupation = {
-                #     "TOP": [],
-                #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-                #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-                #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-                #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-                # }
                 roles_occupation = {
                     "TOP": [],
-                    "JUNGLE": [],
-                    "MID": [],
-                    "ADC": [],
-                    "SUPPORT": []
+                    "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+                    "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+                    "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+                    "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
                 }
+                # roles_occupation = {
+                #     "TOP": [],
+                #     "JUNGLE": [],
+                #     "MID": [],
+                #     "ADC": [],
+                #     "SUPPORT": []
+                # }
 
                 for data in member_data:
                     member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")
@@ -693,7 +694,12 @@ class QueueButtons(ui.View):
         await inter.response.defer()
         st_pref = await self.bot.fetchrow(f"SELECT * FROM switch_team_preference WHERE guild_id = {inter.guild.id}")
         if not st_pref:
-            return await inter.send(embed=error("Switch teams is not available with MMR system enabled."), ephemeral=True)
+            for button in self.children:
+                if button.label == "Switch Team":
+                    if not button.disabled:
+                        button.disabled = True
+                        await inter.message.edit(view=self)
+            return await inter.send(embed=error("Switch teams is not available with SBMM system enabled."), ephemeral=True)
         
         data = await self.bot.fetchrow(
             f"SELECT * FROM game_member_data WHERE author_id = {inter.author.id} and game_id = '{self.game_id}'"

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -229,8 +229,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            if len(ready_ups) == 2:
-            # if len(ready_ups) == 10:
+            # if len(ready_ups) == 2:
+            if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -475,27 +475,27 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        if checks_passed == 1:
-        # if checks_passed == len(self.children) - 1:
+        # if checks_passed == 1:
+        if checks_passed == len(self.children) - 1:
             member_data = await self.bot.fetch(
                 f"SELECT * FROM game_member_data WHERE game_id = '{self.game_id}'"
             )
 
             # CHECK
-            roles_occupation = {
-                "TOP": [],
-                "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-                "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-                "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-                "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-            }
             # roles_occupation = {
             #     "TOP": [],
-            #     "JUNGLE": [],
-            #     "MID": [],
-            #     "ADC": [],
-            #     "SUPPORT": []
+            #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+            #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+            #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+            #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
             # }
+            roles_occupation = {
+                "TOP": [],
+                "JUNGLE": [],
+                "MID": [],
+                "ADC": [],
+                "SUPPORT": []
+            }
 
             for data in member_data:
                 member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/match.py
+++ b/cogs/match.py
@@ -227,8 +227,8 @@ class ReadyButton(ui.View):
             )
 
             # CHECK
-            # if len(ready_ups) == 2:
-            if len(ready_ups) == 10:
+            if len(ready_ups) == 2:
+            # if len(ready_ups) == 10:
                 preference = await self.bot.fetchrow(f"SELECT * FROM queue_preference WHERE guild_id = {inter.guild.id}")
                 if preference:
                     preference = preference[1]
@@ -442,11 +442,13 @@ class QueueButtons(ui.View):
                     button.style = ButtonStyle.grey
 
         await self.bot.execute(
-            "INSERT INTO game_member_data(author_id, role, team, game_id) VALUES($1, $2, $3, $4)",
+            "INSERT INTO game_member_data(author_id, role, team, game_id, queue_id, channel_id) VALUES($1, $2, $3, $4, $5, $6)",
             inter.author.id,
             label,
             team,
             self.game_id,
+            inter.message.id,
+            inter.channel.id
         )
 
         embed = await self.gen_embed(inter.message)
@@ -471,27 +473,27 @@ class QueueButtons(ui.View):
                 checks_passed += 1
 
         # CHECK
-        # if checks_passed == 1:
-        if checks_passed == len(self.children) - 1:
+        if checks_passed == 1:
+        # if checks_passed == len(self.children) - 1:
             member_data = await self.bot.fetch(
                 f"SELECT * FROM game_member_data WHERE game_id = '{self.game_id}'"
             )
 
             # CHECK
-            # roles_occupation = {
-            #     "TOP": [],
-            #     "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
-            #     "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
-            #     "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
-            #     "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
-            # }
             roles_occupation = {
                 "TOP": [],
-                "JUNGLE": [],
-                "MID": [],
-                "ADC": [],
-                "SUPPORT": []
+                "JUNGLE": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()},],
+                "MID": [{'user_id': 789, 'rating': Rating()}, {'user_id': 901, 'rating': Rating()}, ],
+                "ADC": [{'user_id': 234, 'rating': Rating()}, {'user_id': 567, 'rating': Rating()}, ],
+                "SUPPORT": [{'user_id': 890, 'rating': Rating()}, {'user_id': 3543, 'rating': Rating()}]
             }
+            # roles_occupation = {
+            #     "TOP": [],
+            #     "JUNGLE": [],
+            #     "MID": [],
+            #     "ADC": [],
+            #     "SUPPORT": []
+            # }
 
             for data in member_data:
                 member_rating = await self.bot.fetchrow(f"SELECT * FROM mmr_rating WHERE user_id = {data[0]}")

--- a/cogs/opgg.py
+++ b/cogs/opgg.py
@@ -57,7 +57,7 @@ class OP_GG(Cog):
             pattern2 = re.compile("ign: ", re.IGNORECASE)
             nick = pattern2.sub("", nick)
 
-            nicknames.append(str(nick))
+            nicknames.append(str(nick).replace(' ', '%20'))
 
         for i, nick in enumerate(nicknames):
             if not i == 0:

--- a/cogs/opgg.py
+++ b/cogs/opgg.py
@@ -1,0 +1,72 @@
+from core.embeds import error, success
+from disnake import *
+from disnake.ext.commands import *
+import re
+
+class OP_GG(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @slash_command()
+    async def opgg(
+        self,
+        ctx,
+        game_id,
+        team = Param(
+            choices=[
+                OptionChoice('Blue', 'blue'),
+                OptionChoice('Red', 'red')
+            ]
+        ),
+        region = Param(
+            choices=[
+                OptionChoice('euw', 'euw'),
+                OptionChoice('na', 'na'),
+                OptionChoice('eune', 'eune'),
+                OptionChoice('oce', 'oce'),
+                OptionChoice('kr', 'kr'),
+                OptionChoice('jp', 'jp'),
+                OptionChoice('br', 'br'),
+                OptionChoice('las', 'las'),
+                OptionChoice('lan', 'lan'),
+                OptionChoice('ru', 'ru'),
+                OptionChoice('tr', 'tr')
+            ]
+        ),
+        ):
+        """
+        Generate an op.gg link for a team.
+        """
+        
+        url = f'https://www.op.gg/multisearch/{region}?summoners='
+        nicknames = []
+        data = await self.bot.fetch(f"SELECT * FROM game_member_data WHERE game_id = '{game_id}' and team = '{team}'")
+        if not data:
+            return await ctx.send(embed=error("Game not found."))
+        for entry in data:
+            member = ctx.guild.get_member(entry[0])
+            if member.nick:
+                nick = member.nick
+            else:
+                nick = member.name
+
+            
+            pattern = re.compile("ign ", re.IGNORECASE)
+            nick = pattern.sub("", nick)
+
+            pattern2 = re.compile("ign: ", re.IGNORECASE)
+            nick = pattern2.sub("", nick)
+
+            nicknames.append(str(nick))
+
+        for i, nick in enumerate(nicknames):
+            if not i == 0:
+                url += "%2C"
+            url += f"{nick}"
+
+        await ctx.send(
+            embed=success(url)
+        )
+
+def setup(bot):
+    bot.add_cog(OP_GG(bot))

--- a/cogs/opgg.py
+++ b/cogs/opgg.py
@@ -4,6 +4,9 @@ from disnake.ext.commands import *
 import re
 
 class OP_GG(Cog):
+    """
+    🔗;OP.GG
+    """
     def __init__(self, bot):
         self.bot = bot
 

--- a/core/buttons.py
+++ b/core/buttons.py
@@ -1,0 +1,32 @@
+from disnake import ui, ButtonStyle
+
+
+class ConfirmationButtons(ui.View):
+    def __init__(self, authorid):
+        super().__init__(timeout=120.0)
+        self.value = None
+        self.authorid = authorid
+
+    @ui.button(emoji="✖️", style=ButtonStyle.red)
+    async def first_button(self, button, inter):
+        if inter.author.id != self.authorid:
+            return await inter.send(
+                "You cannot interact with these buttons.", ephemeral=True
+            )
+        self.value = False
+        for button in self.children:
+            button.disabled = True
+        await inter.response.edit_message(view=self)
+        self.stop()
+
+    @ui.button(emoji="✔️", style=ButtonStyle.green)
+    async def second_button(self, button, inter):
+        if inter.author.id != self.authorid:
+            return await inter.send(
+                "You cannot interact with these buttons.", ephemeral=True
+            )
+        self.value = True
+        for button in self.children:
+            button.disabled = True
+        await inter.response.edit_message(view=self)
+        self.stop()

--- a/main.py
+++ b/main.py
@@ -74,7 +74,11 @@ intents.members = True
 bot = MyBot(intents=intents, command_prefix=PREFIX)
 bot.remove_command("help")
 
-
+@bot.before_slash_command_invoke
+async def before_invoke_slash(inter):
+    if not inter.response.is_done():
+        await inter.response.defer()
+        
 # Load all cogs
 for filename in os.listdir("./cogs"):
     if filename.endswith(".py"):


### PR DESCRIPTION
Requires 2 new columns in game_member_data table. (IMPORTANT)

queue_id INTEGER
channel_id INTEGER

`/admin reset user` will not work for queues made before this update.


# Features - 
- Bug Fix - Can now remove someone from the ready up check
- Rank command - See your rank 
- Void Command - Needed to bypass the rare bug when members would get stuck in a game
- Switch team - Can now disable/enable MMR gains and matchmaking
- 1.5sec delay - Slight delay when selecting role, this should hopefully reduce the chances of there being 2 roles on the same team due to players clicking the same role at the same time
- Multi op. gg link for blue and red team command
- Extra check to let the user know that all messages will be deleted in the queue channel 