### PR TITLE
delete queues once game is finished, reset leaderboard properly

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -89,15 +89,17 @@ class Admin(Cog):
     async def leaderboard(self, ctx):
         data = await self.bot.fetch(f"SELECT * FROM points WHERE guild_id = {ctx.guild.id} ")
         if not data:
-            return await ctx.send(embed=error("There are no records to be deleted."))
-        
+            return await ctx.send(embed=error("There are no records to be deleted"))
+
+        await self.bot.execute(f"DELETE FROM mvp_points WHERE guild_id = {ctx.guild.id}")
         await self.bot.execute(f"DELETE FROM points WHERE guild_id = {ctx.guild.id}")
-        await ctx.send(embed=success("Successfully removed all previous records of leaderboard."))
+        await self.bot.execute(f"DELETE FROM mmr_rating WHERE guild_id = {ctx.guild.id}")
+        await ctx.send(embed=success("Successfully reset all wins, mmr and mvp votes"))
 
     @reset_slash.sub_command(name="leaderboard")
     async def leaderboard_slash(self, ctx):
         """
-        Reset your server's leaderboard.
+        Reset your entire servers Wins, Losses, MMR and MVP votes back to 0.
         """
         await self.leaderboard(ctx)
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -231,6 +231,41 @@ class Events(Cog):
     async def on_slash_command_error(self, ctx, error):
         await self.on_command_error(ctx, error)
 
+    @Cog.listener('on_message')
+    async def delete_queue_messages(self, msg):
+        data = await self.bot.fetch("SELECT * FROM queuechannels")
+        if not data:
+            return
+
+        channels = [channel[0] for channel in data]
+
+        # This is designed to ignore all the messages sent from !start
+        if msg.channel.id in channels:
+            embed = msg.embeds
+            if not embed:
+                try:
+                    await msg.delete()
+                except:
+                    pass
+                return
+            else:
+                embed = msg.embeds[0]
+            if (
+                    (not embed.title == "Match Overview - SR Tournament Draft")
+                    and (not embed.description == "Game was found! Time to ready up!")
+                    and (
+                    not embed.description
+                        == "Mentioned players have been removed from the queue for not being ready on time."
+            )
+                    and (
+                    not embed.title == ":warning: NOTICE"
+            )
+            ):
+                try:
+                    await msg.delete()
+                except:
+                    pass
+
     @Cog.listener()
     async def on_message(self, msg):
         if msg.author.bot or msg.guild:

--- a/cogs/win.py
+++ b/cogs/win.py
@@ -182,6 +182,7 @@ class Win(Cog):
             log_channel = self.bot.get_channel(log_channel_id[0])
             if log_channel:
                 await log_channel.send(mentions, embed=embed)
+                await msg.delete()
 
         await self.bot.execute(f"DELETE FROM games WHERE game_id = '{game_data[0]}'")
         await self.bot.execute(


### PR DESCRIPTION
- Delete messages in the queue
- Delete the queue once the game is over
- Reset leaderboard now resets MMR and MVP votes