### PR TITLE
fixed duo queue

### DIFF
--- a/core/match.py
+++ b/core/match.py
@@ -407,6 +407,9 @@ class LeaveButton(ui.Button):
             await self.bot.execute(
                 f"DELETE FROM game_member_data WHERE author_id = {inter.author.id} and game_id = '{view.game_id}'"
             )
+            await self.bot.execute(
+                f"DELETE FROM duo_queue WHERE user1_id = {inter.author.id} AND game_id = '{view.game_id}' OR user2_id = {inter.author.id} AND game_id = '{view.game_id}'"
+            )
 
             embed = await view.gen_embed(inter.message, view.game_id)
 


### PR DESCRIPTION
#253


- What happens when one person in a duo leaves the queue?
This case wasn't considered while testing that is why we had this issue. Fix is ready and in it, we will simply delete the records of their duo which answers rest of the questions.

- What happens if they rejoin, are they still duo'd? or will they need to go through the system again?
They will need to go through the system again, since we deleted the records and the other person may join with duo incompatible role
 
- When one of the duos leave, the emoji is still there. Should we remove it? or do we keep it?
It will be removed from the other member once one duo member leaves the queue.

- Is that person now locked out from duo'ing with someone else?
No, they can duo with someone else 
